### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-04-09
+
+### Added
+- kubeconform schema validation in CI
+- Upgrade test (install then re-apply) in CI
+- `examples/nebari-values.yaml` — canonical ArgoCD Application example for Nebari deployments
+- `examples/standalone-values.yaml` — minimal values for non-Nebari deployments
+- Pinned container images: MLflow `3.7.0`, PostgreSQL `17.5.0`
+
+### Changed
+- Consolidated ArgoCD Application example and Helm values into single `nebari-values.yaml`
+
 ## [0.0.1] - 2026-04-01
 
 ### Added

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nebari-mlflow-pack
 description: A Helm chart for deploying MLflow on Kubernetes with optional Nebari platform integration
 type: application
-version: 0.0.1
+version: 1.0.0
 appVersion: "3.7.0"
 
 dependencies:

--- a/examples/nebari-values.yaml
+++ b/examples/nebari-values.yaml
@@ -16,7 +16,7 @@ spec:
   source:
     chart: nebari-mlflow-pack
     repoURL: https://nebari-dev.github.io/nebari-mlflow-pack
-    targetRevision: 0.0.1
+    targetRevision: 1.0.0
     helm:
       releaseName: mlflow-pack
       values: |


### PR DESCRIPTION
## Summary
Bump chart version to 1.0.0. Updates CHANGELOG and example targetRevision.

## What's in 1.0.0
- NebariApp integration (routing, TLS, Keycloak auth via nebari-operator)
- Bundled PostgreSQL with `existingSecret` support
- Auto-whitelisted allowed hosts (no need to disable security middleware)
- Landing page support
- Pinned container images (MLflow 3.7.0, PostgreSQL 17.5.0)
- CI: helm lint, kubeconform, standalone test, integration test, upgrade test
- Examples: `nebari-values.yaml` (ArgoCD), `standalone-values.yaml`
- Docs: README, auth flow guide, NebariApp CRD reference

## Test plan
- [ ] CI passes (lint, test, integration)
- [ ] Merge, then trigger release workflow
- [ ] Verify chart available at `nebari-dev.github.io/nebari-mlflow-pack`
- [ ] Update gitops repo to `targetRevision: 1.0.0` and verify deployment