### PR TITLE
chore: sync pack name with renamed repo and set level to alpha

### DIFF
--- a/pack-metadata.yaml
+++ b/pack-metadata.yaml
@@ -23,7 +23,7 @@
 
 # Must equal the GitHub repo name exactly (e.g. "nebari-data-science-pack").
 # The dashboard uses this to cross-check that the file is in the right repo.
-name: nebari-mlflow-pack
+name: mlflow-pack
 
 # Human-readable name shown on the dashboard. Title-case recommended.
 display_name: MLflow Pack
@@ -31,7 +31,7 @@ display_name: MLflow Pack
 # Maturity level. Must be lowercase. Allowed values: experimental | alpha | beta | ga
 # Definitions, per-level promotion checklist, and dashboard flag reference:
 #   https://github.com/nebari-dev/nebari-software-pack-template/blob/main/docs/release-readiness-checklist.md
-level: experimental
+level: alpha
 
 # GitHub username of the accountable engineer. No "@" prefix.
 # For packs with multiple maintainers, name the single most-accountable one


### PR DESCRIPTION
Updates pack-metadata.yaml so the dashboard row renders cleanly:

- `name` now matches the renamed repo, clearing the `metadata-invalid` flag on the pack dashboard
- `level` set to alpha

Part of a sweep across all pack repos to align dashboard metadata.